### PR TITLE
The method does not exist

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ static void Main(string[] _args)
 ### OR
 
 ```cs
-	r_NetworkCallback.r_NetworkCallback("event_name", (id, packet) =>
+	r_NetworkCallback.RegisterCallback("event_name", (id, packet) =>
 	{
 		//code
 	});


### PR DESCRIPTION
I'm pretty sure this "r_NetworkCallback.r_NetworkCallback" method doesn't exist, I think it's "r_NetworkCallback.RegisterCallback"